### PR TITLE
Add BaseAdapter class

### DIFF
--- a/app/core/adapters/base.py
+++ b/app/core/adapters/base.py
@@ -1,0 +1,16 @@
+from abc import ABCMeta, abstractmethod
+
+from pydantic import BaseSettings
+
+from app.settings import settings
+
+from ..schemas import EmailSchema
+
+
+class BaseAdapter(metaclass=ABCMeta):
+    def __init__(self, settings: BaseSettings = settings):
+        self.settings = settings
+
+    @abstractmethod
+    def send(self, message: EmailSchema):
+        ...


### PR DESCRIPTION
## What

This PR adds the `BaseAdapter` class, which must be extended by any email service adapter that get implemented.