### PR TITLE
Add security

### DIFF
--- a/app/api/security.py
+++ b/app/api/security.py
@@ -11,7 +11,7 @@ API_KEY_HEADER = APIKeyHeader(name="x-api-key")
 
 
 class ApiKeyChecker:
-    def __init__(self, settings=settings):
+    def __init__(self, settings: BaseSettings = settings):
         self.settings = settings
 
     def __call__(self, api_key: str = Security(API_KEY_HEADER)):

--- a/app/api/security.py
+++ b/app/api/security.py
@@ -1,0 +1,24 @@
+from fastapi import Security, HTTPException
+from fastapi.security.api_key import APIKeyHeader
+from pydantic import BaseSettings
+
+from starlette.status import HTTP_403_FORBIDDEN
+
+from app.settings import settings
+
+
+API_KEY_HEADER = APIKeyHeader(name="x-api-key")
+
+
+class ApiKeyChecker:
+    def __init__(self, settings=settings):
+        self.settings = settings
+
+    def __call__(self, api_key: str = Security(API_KEY_HEADER)):
+        if api_key != self.settings.API_KEY:
+            raise HTTPException(
+                status_code=HTTP_403_FORBIDDEN, detail="Could not validate credentials"
+            )
+
+
+api_key_checker = ApiKeyChecker()

--- a/app/settings.py
+++ b/app/settings.py
@@ -2,6 +2,7 @@ from pydantic import BaseSettings, EmailStr
 
 
 class Settings(BaseSettings):
+    API_KEY: str = "you-will-want-something-safe-here"
     DEFAULT_EMAIL_ADDRESS: EmailStr = "default@email.com"
     SENDGRID_API_KEY: str = "get_your_api_key_from_sendgrid_dashboard"
 

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -1,0 +1,21 @@
+from fastapi import HTTPException
+from pytest import fixture, raises
+
+from app.api.security import ApiKeyChecker
+from app.settings import Settings
+
+settings = Settings(API_KEY="some-secret-key")
+
+
+@fixture
+def checker():
+    return ApiKeyChecker(settings=settings)
+
+
+def test_checker_throws_exception_for_invalid_key(checker):
+    with raises(HTTPException):
+        checker(f"not-quite-{settings.API_KEY}")
+
+
+def test_checker_passes_for_valid_key(checker):
+    checker(settings.API_KEY)

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,6 +1,17 @@
 from app.settings import Settings
 
 
+def test_api_key_is_set_from_env(monkeypatch):
+    expected = "this_is_an_api_key"
+    monkeypatch.setenv("API_KEY", expected)
+    assert Settings(_env_file=None).API_KEY == expected
+
+
+def test_api_key_has_default_value(monkeypatch):
+    monkeypatch.delenv("API_KEY", raising=False)
+    assert isinstance(Settings(_env_file=None).API_KEY, str)
+
+
 def test_default_email_address_is_set_from_env(monkeypatch):
     expected = "some@email.com"
     monkeypatch.setenv("DEFAULT_EMAIL_ADDRESS", expected)


### PR DESCRIPTION
## What

This PR sets up basic security configs with an `API_KEY` sent through `x-api-key` header.