### PR TITLE
Enable security on router

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,6 +1,9 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
 
 from .routers import emails_router
+from .security import api_key_checker
 
 api = FastAPI()
-api.include_router(emails_router, tags=["emails"])
+api.include_router(
+    emails_router, tags=["emails"], dependencies=[Depends(api_key_checker)]
+)

--- a/tests/unit/routers/conftest.py
+++ b/tests/unit/routers/conftest.py
@@ -2,8 +2,17 @@ from pytest import fixture
 from starlette.testclient import TestClient
 
 from app.api import api
+from app.api.security import ApiKeyChecker, api_key_checker
+from app.settings import Settings
 
 
 @fixture
-def client():
-    return TestClient(api)
+def settings():
+    return Settings(API_KEY="secret-api-key")
+
+
+@fixture
+def client(settings):
+    client = TestClient(api)
+    api.dependency_overrides[api_key_checker] = ApiKeyChecker(settings)
+    return client

--- a/tests/unit/routers/test_emails_router.py
+++ b/tests/unit/routers/test_emails_router.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 from pytest import fixture
 from starlette.status import (
     HTTP_202_ACCEPTED,
+    HTTP_403_FORBIDDEN,
     HTTP_405_METHOD_NOT_ALLOWED,
     HTTP_422_UNPROCESSABLE_ENTITY,
 )
@@ -10,7 +11,6 @@ from starlette.status import (
 from app.api import api
 from app.core.adapters import SendgridAdapter
 from app.core.schemas import EmailSchema
-
 
 message_dict = {
     "from": "from@email.com",
@@ -24,9 +24,11 @@ message = EmailSchema(**message_dict)
 
 
 @fixture(scope="function")
-def send_response(client):
+def send_response(client, settings):
     SendgridAdapter.send = MagicMock()
-    yield client.post("/emails", json=message_dict)
+    yield client.post(
+        "/emails", json=message_dict, headers={"x-api-key": settings.API_KEY}
+    )
     SendgridAdapter.send.assert_called_once_with(message)
 
 
@@ -34,10 +36,17 @@ def test_send_email_endpoint_should_accept_post(send_response):
     assert send_response.status_code != HTTP_405_METHOD_NOT_ALLOWED
 
 
-def test_send_email_should_validate_input(client):
-    response = client.post("/emails", json={})
+def test_send_email_should_validate_input(client, settings):
+    response = client.post("/emails", json={}, headers={"x-api-key": settings.API_KEY})
     assert response.status_code == HTTP_422_UNPROCESSABLE_ENTITY
 
 
 def test_send_email_should_return_status_202(send_response):
     assert send_response.status_code == HTTP_202_ACCEPTED
+
+
+def test_send_email_should_return_status_403_if_not_authorized(client, settings):
+    response = client.post(
+        "/emails", json={}, headers={"x-api-key": f"not-quite-{settings.API_KEY}"}
+    )
+    assert response.status_code == HTTP_403_FORBIDDEN


### PR DESCRIPTION
## What

This PR enables security on the `/emails` endpoint, which will require an `x-api-key` header to be sent to authorize requests.