### PR TITLE
Enforce https

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,12 +1,13 @@
 from fastapi import FastAPI, Depends
 
-from . import sentry
+from . import https, sentry
 from .routers import emails_router
 from .security import api_key_checker
 
 sentry.configure()
 
 api = FastAPI()
+https.configure(api)
 api.include_router(
     emails_router, tags=["emails"], dependencies=[Depends(api_key_checker)]
 )

--- a/app/api/https.py
+++ b/app/api/https.py
@@ -1,0 +1,8 @@
+from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
+
+from ..settings import settings
+
+
+def configure(app, settings=settings):
+    if settings.ENV != "dev":
+        app.add_middleware(HTTPSRedirectMiddleware)

--- a/app/settings.py
+++ b/app/settings.py
@@ -2,6 +2,7 @@ from pydantic import BaseSettings, EmailStr
 
 
 class Settings(BaseSettings):
+    ENV: str = "dev"
     SENTRY_DSN: str = None
     API_KEY: str = "you-will-want-something-safe-here"
     DEFAULT_EMAIL_ADDRESS: EmailStr = "default@email.com"


### PR DESCRIPTION
## What

This PR makes use of the `HTTPSRedirectMiddleware` to enforce HTTPS connections on environments that are not `dev`