### PR TITLE
Make test settings ignore .env file

### DIFF
--- a/tests/unit/adapters/test_sendgrid_adapter.py
+++ b/tests/unit/adapters/test_sendgrid_adapter.py
@@ -9,7 +9,9 @@ from app.core.schemas import EmailSchema
 from app.settings import Settings
 
 settings = Settings(
-    DEFAULT_EMAIL_ADDRESS="some@email.com", SENDGRID_API_KEY="some_api_key",
+    _env_file=None,
+    DEFAULT_EMAIL_ADDRESS="some@email.com",
+    SENDGRID_API_KEY="some_api_key",
 )
 
 message = EmailSchema(

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -4,7 +4,7 @@ from pytest import fixture, raises
 from app.api.security import ApiKeyChecker
 from app.settings import Settings
 
-settings = Settings(API_KEY="some-secret-key")
+settings = Settings(_env_file=None, API_KEY="some-secret-key")
 
 
 @fixture


### PR DESCRIPTION
## What

This PR makes tests ignore any .env file available, so local testing isn't affected by it.