### PR TITLE
Add worker

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -17,10 +17,12 @@ class Settings(BaseSettings):
     SENDGRID_API_KEY: str = "get_your_api_key_from_sendgrid_dashboard"
     MAILJET_API_KEY: str = "get_your_api_key_from_mailjet_dashboard"
     MAILJET_API_SECRET: str = "get_your_api_secret_from_mailjet_dashboard"
+    BROKER_URL: str = "amqp://localhost"
 
     class Config:
         env_file = ".env"
         case_sensitive = True
+        fields = {"BROKER_URL": {"env": ["BROKER_URL", "CLOUDAMQP_URL"]}}
 
 
 settings = Settings()

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Optional
 
 from pydantic import BaseSettings, EmailStr
 
@@ -18,6 +19,7 @@ class Settings(BaseSettings):
     MAILJET_API_KEY: str = "get_your_api_key_from_mailjet_dashboard"
     MAILJET_API_SECRET: str = "get_your_api_secret_from_mailjet_dashboard"
     BROKER_URL: str = "amqp://localhost"
+    BROKER_POOL_LIMIT: Optional[int] = 1
 
     class Config:
         env_file = ".env"

--- a/app/settings.py
+++ b/app/settings.py
@@ -18,7 +18,7 @@ class Settings(BaseSettings):
     SENDGRID_API_KEY: str = "get_your_api_key_from_sendgrid_dashboard"
     MAILJET_API_KEY: str = "get_your_api_key_from_mailjet_dashboard"
     MAILJET_API_SECRET: str = "get_your_api_secret_from_mailjet_dashboard"
-    BROKER_URL: str = "amqp://localhost"
+    BROKER_URL: str = "amqp://rabbitmq:rabbitmq@localhost"
     BROKER_POOL_LIMIT: Optional[int] = 1
 
     class Config:

--- a/app/worker/__init__.py
+++ b/app/worker/__init__.py
@@ -1,0 +1,6 @@
+from celery import Celery
+
+from app.settings import settings
+
+worker = Celery("worker", broker=settings.BROKER_URL, include=["app.worker.tasks"])
+worker.conf.update(broker_pool_limit=settings.BROKER_POOL_LIMIT)

--- a/app/worker/tasks/__init__.py
+++ b/app/worker/tasks/__init__.py
@@ -1,0 +1,1 @@
+from .emails import send_email

--- a/app/worker/tasks/emails.py
+++ b/app/worker/tasks/emails.py
@@ -1,0 +1,13 @@
+from pydantic import validate_arguments
+
+from app.core.adapters import get_active_adapter
+from app.core.schemas import EmailSchema
+
+from .. import worker
+
+
+@worker.task
+@validate_arguments
+def send_email(message: EmailSchema):
+    adapter = get_active_adapter()
+    return adapter.send(message)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: "3"
+
+services:
+  broker:
+    image: rabbitmq:3.8.3-alpine
+    container_name: "email-sender-broker"
+    environment:
+      RABBITMQ_DEFAULT_USER: "rabbitmq"
+      RABBITMQ_DEFAULT_PASS: "rabbitmq"
+    ports:
+      - "5672:5672"

--- a/makefile
+++ b/makefile
@@ -3,10 +3,18 @@ install:
 	pip install -r requirements-dev.txt && \
 	pre-commit install
 
+.PHONY: broker_init
+broker_init:
+	docker-compose up -d broker
+
 .PHONY: test
 test:
 	PYTHONPATH=. \
 	python -m pytest --cov=app
+
+.PHONY: run_worker
+run_worker: broker_init
+	celery -A app.worker worker --loglevel debug
 
 .PHONY: run
 run:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+celery==4.4.2
 email-validator==1.1.1
 fastapi==0.54.1
 mailjet-rest==1.3.3

--- a/tests/unit/tasks/test_emails_tasks.py
+++ b/tests/unit/tasks/test_emails_tasks.py
@@ -1,0 +1,29 @@
+from unittest.mock import MagicMock, patch
+
+from pydantic import ValidationError
+from pytest import fixture, raises
+
+from app.core.schemas import EmailSchema
+from app.worker.tasks.emails import send_email
+
+mock_adapter = MagicMock()
+
+message = EmailSchema(
+    **{"to": "some@email.com", "subject": "subject", "content": "content"}
+)
+
+
+@fixture(autouse=True)
+def mock_get_active_adapter():
+    with patch("app.worker.tasks.emails.get_active_adapter", return_value=mock_adapter):
+        yield
+
+
+def test_task_send_email_validates_payload():
+    with raises(ValidationError):
+        send_email({})
+
+
+def test_task_send_email_calls_adapter():
+    send_email(message)
+    mock_adapter.send.assert_called_once_with(message)


### PR DESCRIPTION
## What

This PR starts to set up the worker service which is a `celery` application that consumes messages from `RabbitMQ`. Further development is needed to make the API post messages instead of calling the email adapters directly.