### PR TITLE
Add ENV to app setup

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,6 +2,10 @@
   "name": "email-sender",
   "repository": "https://github.com/umluizlima/email-sender",
   "env": {
+    "ENV": {
+      "description": "The environment in which to run the application.",
+      "value": "prod"
+    },
     "API_KEY": {
       "description": "A secret key for API authentication.",
       "generator": "secret"


### PR DESCRIPTION
## What

This PR fixes the default Heroku deployment config to have the `ENV` set to `prod`, which will automatically enable https enforcing on the API.