### PR TITLE
Update api

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: uvicorn --host=0.0.0.0 --port=$PORT app.api:api
+worker: celery worker --app=app.worker

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: uvicorn --host=0.0.0.0 --port=$PORT app.api:api
-worker: celery worker --app=app.worker
+worker: celery worker --app=app.worker --loglevel info

--- a/app.json
+++ b/app.json
@@ -10,5 +10,6 @@
       "description": "A secret key for API authentication.",
       "generator": "secret"
     }
-  }
+  },
+  "addons": ["cloudamqp:lemur"]  
 }

--- a/app/api/routers/emails.py
+++ b/app/api/routers/emails.py
@@ -1,12 +1,12 @@
 from fastapi import APIRouter, Depends
 from starlette.status import HTTP_202_ACCEPTED
 
-from app.core.adapters import BaseAdapter, get_active_adapter
 from app.core.schemas import EmailSchema
+from app.core.tasks import get_tasks_producer, Task
 
 router = APIRouter()
 
 
 @router.post("/emails", status_code=HTTP_202_ACCEPTED)
-def send(message: EmailSchema, adapter: BaseAdapter = Depends(get_active_adapter)):
-    return adapter.send(message)
+def send(message: EmailSchema, producer=Depends(get_tasks_producer)):
+    producer.send_task(Task.SEND_EMAIL, args=[message.dict()])

--- a/app/core/tasks/__init__.py
+++ b/app/core/tasks/__init__.py
@@ -1,2 +1,3 @@
 from .base import get_celery_app, Task
 from .consumer import get_tasks_consumer
+from .producer import get_tasks_producer

--- a/app/core/tasks/producer.py
+++ b/app/core/tasks/producer.py
@@ -1,0 +1,10 @@
+from functools import lru_cache
+
+from app.settings import settings
+
+from .base import get_celery_app
+
+
+@lru_cache
+def get_tasks_producer():
+    return get_celery_app("producer", settings)

--- a/makefile
+++ b/makefile
@@ -16,6 +16,10 @@ test:
 run_worker: broker_init
 	celery -A app.worker worker --loglevel debug
 
+.PHONY: run_api
+run_api: broker_init
+	uvicorn --reload app.api:api
+
 .PHONY: run
 run:
-	uvicorn --reload app.api:api
+	make -j run_worker run_api

--- a/tests/unit/routers/conftest.py
+++ b/tests/unit/routers/conftest.py
@@ -5,24 +5,24 @@ from starlette.testclient import TestClient
 
 from app.api import api
 from app.api.security import ApiKeyChecker, api_key_checker
-from app.core.adapters import get_active_adapter
+from app.core.tasks import get_tasks_producer
 
-mock_adapter = MagicMock()
+mock_producer = MagicMock()
 
 
-def get_active_adapter_override():
-    return mock_adapter
+def get_tasks_producer_override():
+    return mock_producer
 
 
 @fixture
-def adapter():
-    return mock_adapter
+def producer():
+    return mock_producer
 
 
 @fixture
 def client(settings):
     client = TestClient(api)
     api.dependency_overrides[api_key_checker] = ApiKeyChecker(settings)
-    api.dependency_overrides[get_active_adapter] = get_active_adapter_override
+    api.dependency_overrides[get_tasks_producer] = get_tasks_producer_override
     yield client
     api.dependency_overrides = {}

--- a/tests/unit/routers/test_emails_router.py
+++ b/tests/unit/routers/test_emails_router.py
@@ -8,12 +8,12 @@ from starlette.status import (
 
 
 @fixture(scope="function")
-def send_response(adapter, client, message, message_dict, settings):
-    adapter.reset_mock()
+def send_response(producer, client, message, message_dict, settings):
+    producer.reset_mock()
     yield client.post(
         "/emails", json=message_dict, headers={"x-api-key": settings.API_KEY}
     )
-    adapter.send.assert_called_once_with(message)
+    producer.send_task.assert_called_once_with("SEND_EMAIL", args=[message.dict()])
 
 
 def test_send_email_endpoint_should_accept_post(send_response):


### PR DESCRIPTION
## What

This PR adds a task producer that is now used by the API to send emails through the worker, instead of directly calling the service adapters.