### PR TITLE
Update worker tasks register

### DIFF
--- a/app/worker/__init__.py
+++ b/app/worker/__init__.py
@@ -1,9 +1,10 @@
 from app.core.tasks import get_tasks_consumer
 from app.settings import settings
 
-from . import extensions
+from . import extensions, tasks
 
-worker = get_tasks_consumer(settings, include=["app.worker.tasks"])
+worker = get_tasks_consumer(settings)
 worker.conf.update(broker_pool_limit=settings.BROKER_POOL_LIMIT)
 
 extensions.configure(worker, settings)
+tasks.configure(worker, settings)

--- a/app/worker/tasks/__init__.py
+++ b/app/worker/tasks/__init__.py
@@ -1,1 +1,6 @@
-from .emails import send_email
+from .emails import SendEmailTask
+
+
+def configure(app, settings):
+    for task in [SendEmailTask]:
+        app.tasks.register(task)

--- a/app/worker/tasks/__init__.py
+++ b/app/worker/tasks/__init__.py
@@ -3,4 +3,4 @@ from .emails import SendEmailTask
 
 def configure(app, settings):
     for task in [SendEmailTask]:
-        app.tasks.register(task)
+        app.tasks.register(task())

--- a/app/worker/tasks/base.py
+++ b/app/worker/tasks/base.py
@@ -1,0 +1,5 @@
+from celery import Task
+
+
+class BaseTask(Task):
+    pass

--- a/app/worker/tasks/emails.py
+++ b/app/worker/tasks/emails.py
@@ -4,11 +4,15 @@ from app.core.adapters import get_active_adapter
 from app.core.schemas import EmailSchema
 from app.core.tasks import Task
 
-from .. import worker
+from .base import BaseTask
 
 
-@worker.task(name=Task.SEND_EMAIL)
-@validate_arguments
-def send_email(message: EmailSchema):
-    adapter = get_active_adapter()
-    return adapter.send(message)
+class SendEmailTask(BaseTask):
+    name = Task.SEND_EMAIL
+
+    def __init__(self):
+        self.adapter = get_active_adapter()
+
+    @validate_arguments
+    def run(self, message: EmailSchema):
+        return self.adapter.send(message)

--- a/tests/unit/tasks/test_emails_tasks.py
+++ b/tests/unit/tasks/test_emails_tasks.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 from pydantic import ValidationError
 from pytest import fixture, raises
 
-from app.worker.tasks.emails import send_email
+from app.worker.tasks.emails import SendEmailTask
 
 mock_adapter = MagicMock()
 
@@ -16,9 +16,9 @@ def mock_get_active_adapter():
 
 def test_task_send_email_validates_payload():
     with raises(ValidationError):
-        send_email({})
+        SendEmailTask().run({})
 
 
 def test_task_send_email_calls_adapter(message):
-    send_email(message)
+    SendEmailTask().run(message)
     mock_adapter.send.assert_called_once_with(message)


### PR DESCRIPTION
## What

This PR refactors the celery task definition to use class-based tasks and provide a `configure` method for registering all tasks to the worker.